### PR TITLE
Caching

### DIFF
--- a/slackin/slack.py
+++ b/slackin/slack.py
@@ -12,6 +12,7 @@ class SlackError(Exception):
     def __init__(self, message):
         super(SlackError, self).__init__(message)
 
+
 class Slack(object):
     def __init__(self, token, subdomain):
         self.token = token
@@ -32,7 +33,7 @@ class Slack(object):
                 self.handle_error(error_code=response_dict['error'], data=data, user=user)
             return response_dict
         else:
-            raise SlackError('Slack: Invalid API request')
+            raise SlackError('API request failed (status: %s)' % response.status_code)
 
     def handle_error(self, error_code, data, user):
         # generic errors

--- a/slackin/slack.py
+++ b/slackin/slack.py
@@ -15,6 +15,9 @@ log = logging.getLogger(__name__)
 class SlackError(Exception):
     pass
 
+class SlackThrottledCall(SlackError):
+    pass
+
 
 class Slack(object):
     def __init__(self, token, subdomain):
@@ -33,7 +36,8 @@ class Slack(object):
 
         if response.status_code != 200:
             log.error("Slack API call failed (%s) Headers:\n%s", response.status_code, response.headers)
-            raise SlackError('API request failed (status: %s)' % response.status_code)
+            exc_class = SlackThrottledCall if response.status_code == 429 else SlackError
+            raise exc_class('API request failed (status: %s)' % response.status_code)
 
         response_dict = response.json()
         if 'error' in response_dict:

--- a/slackin/slack.py
+++ b/slackin/slack.py
@@ -1,11 +1,15 @@
-import requests
+import logging
 import json
+
+import requests
 
 from slackin.signals import (
     email_address_already_invited,
     email_address_already_in_team,
     sent_invite_to_email_address
 )
+
+log = logging.getLogger(__name__)
 
 
 class SlackError(Exception):
@@ -28,6 +32,7 @@ class Slack(object):
         response = requests.post(url, data=data)
 
         if response.status_code != 200:
+            log.error("Slack API call failed (%s) Headers:\n%s", response.status_code, response.headers)
             raise SlackError('API request failed (status: %s)' % response.status_code)
 
         response_dict = response.json()

--- a/slackin/slack.py
+++ b/slackin/slack.py
@@ -9,8 +9,7 @@ from slackin.signals import (
 
 
 class SlackError(Exception):
-    def __init__(self, message):
-        super(SlackError, self).__init__(message)
+    pass
 
 
 class Slack(object):
@@ -27,15 +26,16 @@ class Slack(object):
             user = data['user']
             del data['user']
         response = requests.post(url, data=data)
-        if response.status_code == 200:
-            response_dict = response.json()
-            if 'error' in response_dict:
-                self.handle_error(error_code=response_dict['error'], data=data, user=user)
-            return response_dict
-        else:
+
+        if response.status_code != 200:
             raise SlackError('API request failed (status: %s)' % response.status_code)
 
-    def handle_error(self, error_code, data, user):
+        response_dict = response.json()
+        if 'error' in response_dict:
+            self.raise_error(error_code=response_dict['error'], data=data, user=user)
+        return response_dict
+
+    def raise_error(self, error_code, data, user):
         # generic errors
         if error_code == 'not_authed':
             raise SlackError('Missing Slack token. Please contact an administrator.')

--- a/slackin/templates/slackin/invite/content.html
+++ b/slackin/templates/slackin/invite/content.html
@@ -1,9 +1,9 @@
 <div class="slackin-content">
     {% block invite_header %}
-        {% if slackin.team.image %}
-            <img src="{{ slackin.team.image }}">
+        {% if slackin.team_image %}
+            <img src="{{ slackin.team_image }}">
         {% endif %}
-        <h1>Join {{ slackin.team.name }} on Slack</h1>
+        <h1>Join {{ slackin.team_name }} on Slack</h1>
         <p><strong>{{ slackin.users_online }}</strong> users online now of <strong>{{ slackin.users_total }}</strong> registered.</p>
     {% endblock invite_header %}
 

--- a/slackin/views.py
+++ b/slackin/views.py
@@ -57,7 +57,7 @@ def get_slack_info():
 
 
 def get_cached_slack_info():
-    return cache.get_or_set('SLACK_CACHE', get_slack_info)
+    return cache.get_or_set('SLACK_CACHE', get_slack_info)  # Default timeout: 5 min
 
 
 class SlackinInviteView(View):

--- a/slackin/views.py
+++ b/slackin/views.py
@@ -75,30 +75,26 @@ class SlackinInviteView(View):
         else:
             return reverse(settings.SLACKIN_LOGIN_REDIRECT)
 
-    def response(self, request):
-        return render(request, template_name=self.template_name, context=self.context)
-
     def get(self, request):
         if settings.SLACKIN_LOGIN_REQUIRED and not self.request.user.is_authenticated():
             return HttpResponseRedirect(self.get_redirect_url())
 
-        self.context = self.get_generic_context()
-
+        context = self.get_generic_context()
         email_address = ''
         if self.request.user.is_authenticated():
             email_address = self.request.user.email
-        self.context['slackin_invite_form'] = SlackinInviteForm(
+        context['slackin_invite_form'] = SlackinInviteForm(
             initial={'email_address': email_address},
             user=self.request.user)
-        return self.response(request)
+        return render(request, template_name=self.template_name, context=context)
 
     def post(self, request):
         if settings.SLACKIN_LOGIN_REQUIRED and not self.request.user.is_authenticated():
             return HttpResponseRedirect(self.get_redirect_url())
 
-        self.context = self.get_generic_context()
+        context = self.get_generic_context()
         invite_form = SlackinInviteForm(self.request.POST, user=self.request.user)
         if invite_form.is_valid():
-            self.context['slackin_invite_form_success'] = True
-        self.context['slackin_invite_form'] = invite_form
-        return self.response(request)
+            context['slackin_invite_form_success'] = True
+        context['slackin_invite_form'] = invite_form
+        return render(request, template_name=self.template_name, context=context)

--- a/slackin/views.py
+++ b/slackin/views.py
@@ -1,63 +1,61 @@
-import time
-
-from django.utils.functional import cached_property
 from django.http import HttpResponseRedirect
 from django.core.urlresolvers import reverse
 from django.core.cache import cache
-
 from django.shortcuts import render
-from django.template import RequestContext
-
 from django.views.generic.base import View
 
 from slackin.conf import settings
-from slackin.slack import Slack
+from slackin.slack import Slack, SlackThrottledCall
 from slackin.forms import SlackinInviteForm
 
 
-class SlackClient(object):
-    def __init__(self, token, subdomain):
-        self._api = Slack(token=token, subdomain=subdomain)
-
-    def get_team(self):
-        response = self._api.get_team()
-        data = response['team']
-        data['image'] = response['team']['icon']['image_132']
-        return {
-            'team': data
-        }
-
-    def _clean_users(self, users):
-        cleaned_users = []
-        for user in users:
-            if (user.get('id') != 'USLACKBOT'
-                    and not user.get('is_bot', False)
-                    and not user.get('deleted', False)):
-                cleaned_users.append(user)
-        return cleaned_users
-
-    def get_users(self):
-        response = self._api.get_users()
-        users_total = self._clean_users(response['members'])
-        users_online = [
-            user
-            for user in users_total
-            if 'presence' in user and user['presence'] == 'active'
-        ]
-        return {
-            'users': users_total,
-            'users_online': len(users_online),
-            'users_total': len(users_total),
-        }
+def is_real_slack_user(member):
+    return not (member.get('id') == 'USLACKBOT' or member.get('is_bot') or member.get('deleted'))
 
 
-def get_slack_info():
-    client = SlackClient(settings.SLACKIN_TOKEN, settings.SLACKIN_SUBDOMAIN)
-    return {**client.get_team(), **client.get_users()}
+class SlackContext(object):
+    CACHE_KEY = 'SLACK_CACHE'
+    CACHE_PERIOD = 60
+    THROTTLED_CACHE_PERIOD = 5
 
+    def __init__(self):
+        self._api = Slack(settings.SLACKIN_TOKEN, settings.SLACKIN_SUBDOMAIN)
 
-def get_cached_slack_info():
-    return cache.get_or_set('SLACK_CACHE', get_slack_info)  # Default timeout: 5 min
+    def fetch(self):
+        data = cache.get(self.CACHE_KEY)
+        if data is None:
+            throttled, data = self._fetch()
+            timeout = self.THROTTLED_CACHE_PERIOD if throttled else self.CACHE_PERIOD
+            cache.set(self.CACHE_KEY, data, timeout=timeout)
+        return data
+
+    def _fetch(self):
+        context = {}
+        throttled = False
+
+        try:
+            response = self._api.get_team()
+        except SlackThrottledCall:
+            context['team_name'] = settings.SLACKIN_SUBDOMAIN
+            context['team_image'] = ''
+            throttled = True
+        else:
+            context['team_name'] = response['team']['name']
+            context['team_image'] = response['team']['icon']['image_132']
+
+        try:
+            response = self._api.get_users()
+        except SlackThrottledCall:
+            context['users_online'] = -1
+            context['users_total'] = -1
+            throttled = True
+        else:
+            users = [member for member in response['members'] if is_real_slack_user(member)]
+            users_online = [user for user in users if user.get('presence') == 'active']
+            context['users_online'] = len(users_online)
+            context['users_total'] = len(users)
+
+        return throttled, context
 
 
 class SlackinInviteView(View):
@@ -65,7 +63,7 @@ class SlackinInviteView(View):
 
     def get_generic_context(self):
         return {
-            'slackin': get_cached_slack_info(),
+            'slackin': SlackContext().fetch(),
             'login_required': settings.SLACKIN_LOGIN_REQUIRED,
         }
 


### PR DESCRIPTION
Nothing perfect here, just an incremental improvement.

Note: 
Slack is throttling those calls, so caching is not optional.
The local dev setup has a dummy cache (never caching), that can be a source of confusion.
Having the status code in the exception help : `429` is `Too Many Requests` : slack is mad.

Ping @mlhamel @nilovna 